### PR TITLE
v1.0.13

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -139,17 +139,9 @@ func (p *Pipeline) Shutdown() {
 }
 
 func (p *Pipeline) ShutdownAndWait() {
-	if p.parameters.CloseEnqueue() {
-		p.parameters.ShutdownAndWait()
-	}
-	if p.inWorker.CloseEnqueue() {
-		p.inWorker.ShutdownAndWait()
-	}
-	if p.outWorker.CloseEnqueue() {
-		p.outWorker.ShutdownAndWait()
-	}
-	if p.doneWorker.CloseEnqueue() {
-		p.doneWorker.ShutdownAndWait()
-	}
+	p.parameters.ShutdownAndWait()
+	p.inWorker.ShutdownAndWait()
+	p.outWorker.ShutdownAndWait()
+	p.doneWorker.ShutdownAndWait()
 	p.done.Wait()
 }

--- a/pipe.go
+++ b/pipe.go
@@ -1,11 +1,18 @@
 package chanque
 
 import (
+	"context"
+	"errors"
 	"sync"
 )
 
 type PipelineInputFunc func(parameter interface{}) (result interface{}, err error)
+
 type PipelineOutputFunc func(result interface{}, err error)
+
+var (
+	ErrPipeClosed = errors.New("pipe queue closed")
+)
 
 type pipe struct {
 	input  interface{}
@@ -21,8 +28,15 @@ type pipeInputResult struct {
 type PipelineOptionFunc func(*optPipeline)
 
 type optPipeline struct {
+	ctx          context.Context
 	panicHandler PanicHandler
 	executor     *Executor
+}
+
+func PipelineContext(ctx context.Context) PipelineOptionFunc {
+	return func(opt *optPipeline) {
+		opt.ctx = ctx
+	}
 }
 
 func PipelinePanicHandler(handler PanicHandler) PipelineOptionFunc {
@@ -39,12 +53,12 @@ func PipelineExecutor(executor *Executor) PipelineOptionFunc {
 
 type Pipeline struct {
 	done       *sync.WaitGroup
+	inFunc     PipelineInputFunc
+	outFunc    PipelineOutputFunc
 	parameters Worker
 	inWorker   Worker
 	outWorker  Worker
 	doneWorker Worker
-	inFunc     PipelineInputFunc
-	outFunc    PipelineOutputFunc
 }
 
 func NewPipeline(inFunc PipelineInputFunc, outFunc PipelineOutputFunc, opts ...PipelineOptionFunc) *Pipeline {
@@ -52,29 +66,41 @@ func NewPipeline(inFunc PipelineInputFunc, outFunc PipelineOutputFunc, opts ...P
 	for _, fn := range opts {
 		fn(opt)
 	}
+	if opt.ctx == nil {
+		opt.ctx = context.Background()
+	}
 	if opt.panicHandler == nil {
 		opt.panicHandler = defaultPanicHandler
 	}
 
-	p := new(Pipeline)
-	p.done = new(sync.WaitGroup)
-	p.inFunc = inFunc
-	p.outFunc = outFunc
+	p := &Pipeline{
+		done:    new(sync.WaitGroup),
+		inFunc:  inFunc,
+		outFunc: outFunc,
+	}
 	p.parameters = NewBufferWorker(p.workerPrepare,
+		WorkerContext(opt.ctx),
 		WorkerPanicHandler(opt.panicHandler),
 		WorkerExecutor(opt.executor),
+		WorkerAbortQueueHandler(p.abortParam),
 	)
 	p.inWorker = NewBufferWorker(p.workerIn,
+		WorkerContext(opt.ctx),
 		WorkerPanicHandler(opt.panicHandler),
 		WorkerExecutor(opt.executor),
+		WorkerAbortQueueHandler(p.abortIn),
 	)
 	p.outWorker = NewBufferWorker(p.workerOut,
+		WorkerContext(opt.ctx),
 		WorkerPanicHandler(opt.panicHandler),
 		WorkerExecutor(opt.executor),
+		WorkerAbortQueueHandler(p.abortOut),
 	)
 	p.doneWorker = NewBufferWorker(p.workerDone,
+		WorkerContext(opt.ctx),
 		WorkerPanicHandler(opt.panicHandler),
 		WorkerExecutor(opt.executor),
+		WorkerAbortQueueHandler(p.abortDone),
 	)
 
 	return p
@@ -121,10 +147,39 @@ func (p *Pipeline) Enqueue(parameter interface{}) bool {
 
 	p.done.Add(1)
 	if ok := p.parameters.Enqueue(pp); ok != true {
-		p.done.Add(-1)
 		return false
 	}
 	return true
+}
+
+func (p *Pipeline) abortParam(parameter interface{}) {
+	pp := parameter.(*pipe)
+
+	pp.result <- &pipeInputResult{nil, ErrPipeClosed}
+	close(pp.result)
+
+	pp.done <- struct{}{}
+	close(pp.done)
+
+	p.done.Done()
+}
+
+func (p *Pipeline) abortIn(parameter interface{}) {
+	pp := parameter.(*pipe)
+	pp.result <- &pipeInputResult{nil, ErrPipeClosed}
+	close(pp.result)
+}
+
+func (p *Pipeline) abortOut(parameter interface{}) {
+	pp := parameter.(*pipe)
+	pp.done <- struct{}{}
+	close(pp.done)
+}
+
+func (p *Pipeline) abortDone(parameter interface{}) {
+	pp := parameter.(*pipe)
+	<-pp.done
+	p.done.Done()
 }
 
 func (p *Pipeline) CloseEnqueue() bool {

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package chanque
 
 const (
-	Version string = "1.0.12"
+	Version string = "1.0.13"
 )

--- a/worker.go
+++ b/worker.go
@@ -138,6 +138,7 @@ func (w *defaultWorker) initWorker() {
 }
 
 func (w *defaultWorker) ForceStop() {
+	w.CloseEnqueue()
 	w.cancel()
 }
 

--- a/worker.go
+++ b/worker.go
@@ -266,8 +266,9 @@ func (w *bufferWorker) Shutdown() {
 }
 
 func (w *bufferWorker) ShutdownAndWait() {
-	w.CloseEnqueue()
-	w.subexec.Wait()
+	if w.CloseEnqueue() {
+		w.subexec.Wait()
+	}
 }
 
 func (w *bufferWorker) CloseEnqueue() bool {

--- a/worker_test.go
+++ b/worker_test.go
@@ -299,82 +299,82 @@ func TestWorkerOptionExecutor(t *testing.T) {
 }
 
 func TestWorkerAbortQueueHandler(t *testing.T) {
-  t.Run("default", func(tt *testing.T) {
+	t.Run("default", func(tt *testing.T) {
 		e := NewExecutor(10, 10)
 		defer e.Release()
 
-    count := 0
-    dequeue := func(p interface{}) {
-      v := p.(int)
-      tt.Logf("dequeue val[%d] = %d", count, v)
-      if v != 123 {
-        tt.Errorf("first value is 123")
-      }
-      count += 1
-    }
-    abortHandler := func(p interface{}) {
-      v := p.(int)
-      tt.Logf("abort val[%d] = %d", count, v)
+		count := 0
+		dequeue := func(p interface{}) {
+			v := p.(int)
+			tt.Logf("dequeue val[%d] = %d", count, v)
+			if v != 123 {
+				tt.Errorf("first value is 123")
+			}
+			count += 1
+		}
+		abortHandler := func(p interface{}) {
+			v := p.(int)
+			tt.Logf("abort val[%d] = %d", count, v)
 
-      if count == 1 {
-        if v != 456 {
-          tt.Errorf("second value is 456")
-        }
-        count += 1
-      }
-      if count == 1 {
-        if v != 789 {
-          tt.Errorf("third value is 789")
-        }
-        count += 1
-      }
-    }
+			if count == 1 {
+				if v != 456 {
+					tt.Errorf("second value is 456")
+				}
+				count += 1
+			}
+			if count == 1 {
+				if v != 789 {
+					tt.Errorf("third value is 789")
+				}
+				count += 1
+			}
+		}
 
-    w := NewDefaultWorker(dequeue, WorkerExecutor(e), WorkerAbortQueueHandler(abortHandler))
+		w := NewDefaultWorker(dequeue, WorkerExecutor(e), WorkerAbortQueueHandler(abortHandler))
 
-    w.Enqueue(123)
-    w.Shutdown() // close enqueue
+		w.Enqueue(123)
+		w.Shutdown() // close enqueue
 
-    w.Enqueue(456)
-    w.Enqueue(789)
-  })
-  t.Run("buffer", func(tt *testing.T) {
+		w.Enqueue(456)
+		w.Enqueue(789)
+	})
+	t.Run("buffer", func(tt *testing.T) {
 		e := NewExecutor(10, 10)
 		defer e.Release()
 
-    count := 0
-    dequeue := func(p interface{}) {
-      v := p.(int)
-      tt.Logf("dequeue val[%d] = %d", count, v)
-      if v != 123 {
-        tt.Errorf("first value is 123")
-      }
-      count += 1
-    }
-    abortHandler := func(p interface{}) {
-      v := p.(int)
-      tt.Logf("abort val[%d] = %d", count, v)
+		count := 0
+		dequeue := func(p interface{}) {
+			v := p.(int)
+			tt.Logf("dequeue val[%d] = %d", count, v)
+			if v != 123 {
+				tt.Errorf("first value is 123")
+			}
+			count += 1
+		}
+		abortHandler := func(p interface{}) {
+			v := p.(int)
+			tt.Logf("abort val[%d] = %d", count, v)
 
-      if count == 1 {
-        if v != 456 {
-          tt.Errorf("second value is 456")
-        }
-        count += 1
-      }
-      if count == 1 {
-        if v != 789 {
-          tt.Errorf("third value is 789")
-        }
-        count += 1
-      }
-    }
+			if count == 1 {
+				if v != 456 {
+					tt.Errorf("second value is 456")
+				}
+				count += 1
+			}
+			if count == 1 {
+				if v != 789 {
+					tt.Errorf("third value is 789")
+				}
+				count += 1
+			}
+		}
 
-    w := NewBufferWorker(dequeue, WorkerExecutor(e), WorkerAbortQueueHandler(abortHandler))
+		w := NewBufferWorker(dequeue, WorkerExecutor(e), WorkerAbortQueueHandler(abortHandler))
 
-    w.Enqueue(123)
-    w.ShutdownAndWait() // close enqueue
+		w.Enqueue(123)
+		w.ShutdownAndWait() // close enqueue
 
-    w.Enqueue(456)
-    w.Enqueue(789)
-  })
+		w.Enqueue(456)
+		w.Enqueue(789)
+	})
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -297,3 +297,84 @@ func TestWorkerOptionExecutor(t *testing.T) {
 		}
 	})
 }
+
+func TestWorkerAbortQueueHandler(t *testing.T) {
+  t.Run("default", func(tt *testing.T) {
+		e := NewExecutor(10, 10)
+		defer e.Release()
+
+    count := 0
+    dequeue := func(p interface{}) {
+      v := p.(int)
+      tt.Logf("dequeue val[%d] = %d", count, v)
+      if v != 123 {
+        tt.Errorf("first value is 123")
+      }
+      count += 1
+    }
+    abortHandler := func(p interface{}) {
+      v := p.(int)
+      tt.Logf("abort val[%d] = %d", count, v)
+
+      if count == 1 {
+        if v != 456 {
+          tt.Errorf("second value is 456")
+        }
+        count += 1
+      }
+      if count == 1 {
+        if v != 789 {
+          tt.Errorf("third value is 789")
+        }
+        count += 1
+      }
+    }
+
+    w := NewDefaultWorker(dequeue, WorkerExecutor(e), WorkerAbortQueueHandler(abortHandler))
+
+    w.Enqueue(123)
+    w.Shutdown() // close enqueue
+
+    w.Enqueue(456)
+    w.Enqueue(789)
+  })
+  t.Run("buffer", func(tt *testing.T) {
+		e := NewExecutor(10, 10)
+		defer e.Release()
+
+    count := 0
+    dequeue := func(p interface{}) {
+      v := p.(int)
+      tt.Logf("dequeue val[%d] = %d", count, v)
+      if v != 123 {
+        tt.Errorf("first value is 123")
+      }
+      count += 1
+    }
+    abortHandler := func(p interface{}) {
+      v := p.(int)
+      tt.Logf("abort val[%d] = %d", count, v)
+
+      if count == 1 {
+        if v != 456 {
+          tt.Errorf("second value is 456")
+        }
+        count += 1
+      }
+      if count == 1 {
+        if v != 789 {
+          tt.Errorf("third value is 789")
+        }
+        count += 1
+      }
+    }
+
+    w := NewBufferWorker(dequeue, WorkerExecutor(e), WorkerAbortQueueHandler(abortHandler))
+
+    w.Enqueue(123)
+    w.ShutdownAndWait() // close enqueue
+
+    w.Enqueue(456)
+    w.Enqueue(789)
+  })
+}


### PR DESCRIPTION
- context.CancelFunc is now always executed when exiting worker dequeue loop
- worker add handler to collect queues that are not processed(AbortQueue)
- avoid blocking when trying to Enqueue after ForceStop in Worker