### PR TITLE
v1.0.20

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package chanque
 
 const (
-	Version string = "1.0.19"
+	Version string = "1.0.20"
 )


### PR DESCRIPTION
Modified to show running jobs in Executor.

- add ExecutorCollectStacktrace option
- add CurrentStacktrace()

example
```
e := chanque.NewExecutor(chanque.ExecutorCollectStacktrace(true))
e.Submit(func() {
  for {
    ... job 1
  }
})
e.Submit(func() {
  for {
    ... job 2
  }
})
os.Stdout.Write(e.CurrentStacktrace())
```